### PR TITLE
Fix coroutines to 8.0 and Add Flow.chunked extension function

### DIFF
--- a/core/src/commonMain/kotlin/kotlinx/document/database/JsonCollection.kt
+++ b/core/src/commonMain/kotlin/kotlinx/document/database/JsonCollection.kt
@@ -2,7 +2,6 @@ package kotlinx.document.database
 
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
-import kotlinx.coroutines.flow.chunked
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flatMapConcat
 import kotlinx.coroutines.flow.map

--- a/core/src/commonMain/kotlin/kotlinx/document/database/Utils.kt
+++ b/core/src/commonMain/kotlin/kotlinx/document/database/Utils.kt
@@ -12,3 +12,22 @@ public fun <T> Flow<T>.drop(count: Long): Flow<T> {
         }
     }
 }
+
+// available in 1.9.0 but not in the version bundled inside intellijIdea
+public fun <T> Flow<T>.chunked(size: Int): Flow<List<T>> {
+    require(size >= 1) { "Expected positive chunk size, but got $size" }
+    return flow {
+        var result: ArrayList<T>? = null // Do not preallocate anything
+        collect { value ->
+            // Allocate if needed
+            val acc = result ?: ArrayList<T>(size).also { result = it }
+            acc.add(value)
+            if (acc.size == size) {
+                emit(acc)
+                // Cleanup, but don't allocate -- it might've been the case this is the last element
+                result = null
+            }
+        }
+        result?.let { emit(it) }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,8 +3,7 @@ h2 = "2.2.224"
 junit = "5.10.3"
 kotlin = "2.0.0"
 kotlin-browser = "1.0.0-pre.764"
-kotlinx-coroutines-core = "1.9.0-RC"
-kotlinx-coroutines-test = "1.8.1"
+kotlinx-coroutines = "1.8.0"
 kotlinx-datetime = "0.6.0"
 kotlinx-io = "0.5.0"
 kotlinx-serialization-json = "1.7.1"
@@ -20,16 +19,16 @@ junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.re
 junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit" }
 kotlin-browser = { module = "org.jetbrains.kotlin-wrappers:kotlin-browser", version.ref = "kotlin-browser" }
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
-kotlin-power-assert-plugin = { module = "org.jetbrains.kotlin:kotlin-power-assert", version.ref="kotlin" }
+kotlin-power-assert-plugin = { module = "org.jetbrains.kotlin:kotlin-power-assert", version.ref = "kotlin" }
 kotlin-serialization-plugin = { module = "org.jetbrains.kotlin:kotlin-serialization", version.ref = "kotlin" }
-kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines-core" }
-kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines-test" }
+kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
 kotlinx-io-core = { module = "org.jetbrains.kotlinx:kotlinx-io-core", version.ref = "kotlinx-io" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
 kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinx-serialization-json" }
 ktlint-gradle = { module = "org.jlleitschuh.gradle:ktlint-gradle", version.ref = "ktlint-gradle" }
-rocksdb-multiplatform = { module="io.maryk.rocksdb:rocksdb-multiplatform", version.ref="rocksdb" }
+rocksdb-multiplatform = { module = "io.maryk.rocksdb:rocksdb-multiplatform", version.ref = "rocksdb" }
 ktor-server-cio = { module = "io.ktor:ktor-server-cio", version.ref = "ktor" }
 ktor-client-js = { module = "io.ktor:ktor-client-js", version.ref = "ktor" }
 ktor-server-content-negotiation = { module = "io.ktor:ktor-server-content-negotiation", version.ref = "ktor" }


### PR DESCRIPTION
Downgrade `kotlinx-coroutines-core` and `kotlinx-coroutines-test` dependencies to version 1.8.0 to match the current IntelliJ configuration. Also, Introduce `chunked` extension function for `Flow` that is available from 1.9